### PR TITLE
Split simulated depth image generation and camera orbit TF broadcaster into separate nodes

### DIFF
--- a/yak_ros2/CMakeLists.txt
+++ b/yak_ros2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(yak_ros2 VERSION 0.1.0 LANGUAGES CXX)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -66,7 +66,7 @@ install(TARGETS ${PROJECT_NAME}_node
 install(DIRECTORY launch demo
         DESTINATION share/${PROJECT_NAME})
 
-if(DEFINED BUILD_DEMO)
+if(BUILD_DEMO)
     find_package(gl_depth_sim REQUIRED)
     find_package(image_transport REQUIRED)
     add_executable(${PROJECT_NAME}_image_simulator
@@ -87,6 +87,18 @@ if(DEFINED BUILD_DEMO)
       ${sensor_msgs_LIBRARIES}
       ${tf2_ros_LIBRARIES}
       )
-    install(TARGETS ${PROJECT_NAME}_image_simulator
+
+    add_executable(${PROJECT_NAME}_tf_broadcaster
+      src/demo/sim_tf_broadcaster.cpp)
+    target_include_directories(${PROJECT_NAME}_tf_broadcaster PUBLIC
+      ${rclcpp_INCLUDE_DIRS}
+      ${tf2_ros_INCLUDE_DIRS}
+      )
+    target_link_libraries(${PROJECT_NAME}_tf_broadcaster
+      Eigen3::Eigen
+      ${rclcpp_LIBRARIES}
+      ${tf2_ros_LIBRARIES}
+      )
+    install(TARGETS ${PROJECT_NAME}_image_simulator ${PROJECT_NAME}_tf_broadcaster
             RUNTIME DESTINATION lib/${PROJECT_NAME})
 endif()

--- a/yak_ros2/launch/demo.launch.py
+++ b/yak_ros2/launch/demo.launch.py
@@ -9,6 +9,7 @@ from ament_index_python.packages import get_package_share_directory
 
 def generate_launch_description():
     ld = LaunchDescription([
+        # Core node for GPU-accelerated 3D reconstruction
         launch_ros.actions.Node(
             node_name='yak_ros2_node', package='yak_ros2', node_executable='yak_ros2_node', output='screen',
             remappings=[('input_depth_image', '/image')],
@@ -29,15 +30,27 @@ def generate_launch_description():
                          'volume_z': 192,
                          }]
             ),
+        # Simulate depth images of a given mesh file
         launch_ros.actions.Node(
             node_name='yak_ros2_image_simulator', package='yak_ros2', node_executable='yak_ros2_image_simulator', output='screen',
             parameters=[{
                          'base_frame': 'world',
-                         'orbit_speed': 1.0,
+                         'camera_frame': 'camera',
                          'framerate': 30.0,
                          'mesh': path.join(get_package_share_directory('yak_ros2'), 'demo', 'bun_on_table.ply'),
                          }]
             ),
+        # Broadcast transforms between the world frame and the camera frame that orbit the camera around the world frame
+        launch_ros.actions.Node(
+            node_name='yak_ros2_tf_broadcaster', package='yak_ros2', node_executable='yak_ros2_tf_broadcaster', output='screen',
+            parameters=[{
+                         'base_frame': 'world',
+                         'camera_frame': 'camera',
+                         'orbit_speed': 1.0,
+                         'hz': 30.0,
+                         }]
+            ),
+        # Fixed transform between the world frame and the origin of the TSDF volume
         launch_ros.actions.Node(
             node_name='static_tf_publisher', package='tf2_ros', node_executable='static_transform_publisher', output='screen',
             arguments=['-0.3', '-0.3', '-0.01', '0', '0', '0', '1', 'world', 'tsdf_origin'],

--- a/yak_ros2/src/demo/sim_depth_image_pub.cpp
+++ b/yak_ros2/src/demo/sim_depth_image_pub.cpp
@@ -92,7 +92,8 @@ int main(int argc, char** argv)
     rate.sleep();
     try
     {
-      geometry_msgs::msg::TransformStamped tf_camera_st = buffer.lookupTransform(base_frame, camera_frame, tf2::TimePointZero);
+      geometry_msgs::msg::TransformStamped tf_camera_st =
+          buffer.lookupTransform(base_frame, camera_frame, tf2::TimePointZero);
       const auto pose = tf2::transformToEigen(tf_camera_st);
       const auto depth_img = sim.render(pose);
 
@@ -106,7 +107,7 @@ int main(int argc, char** argv)
       image.image = cv_img;
       image_pub.publish(image.toImageMsg());
     }
-    catch (tf2::LookupException &e)
+    catch (tf2::LookupException& e)
     {
       RCLCPP_ERROR_STREAM(node->get_logger(), e.what());
     }

--- a/yak_ros2/src/demo/sim_depth_image_pub.cpp
+++ b/yak_ros2/src/demo/sim_depth_image_pub.cpp
@@ -6,7 +6,8 @@
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
 #include <tf2/transform_datatypes.h>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
 #include <tf2_eigen/tf2_eigen.h>
 
 #include <opencv2/highgui.hpp>
@@ -14,20 +15,6 @@
 #include <chrono>
 
 const static std::string DEFAULT_IMAGE_TOPIC = "image";
-
-static Eigen::Isometry3d lookat(const Eigen::Vector3d& origin, const Eigen::Vector3d& eye, const Eigen::Vector3d& up)
-{
-  Eigen::Vector3d z = (eye - origin).normalized();
-  Eigen::Vector3d x = z.cross(up).normalized();
-  Eigen::Vector3d y = z.cross(x).normalized();
-
-  auto p = Eigen::Isometry3d::Identity();
-  p.translation() = origin;
-  p.matrix().col(0).head<3>() = x;
-  p.matrix().col(1).head<3>() = y;
-  p.matrix().col(2).head<3>() = z;
-  return p;
-}
 
 int main(int argc, char** argv)
 {
@@ -37,17 +24,15 @@ int main(int argc, char** argv)
   // Setup ROS interfaces
   image_transport::ImageTransport it(node);
   image_transport::Publisher image_pub = it.advertise(DEFAULT_IMAGE_TOPIC, 1);
-  tf2_ros::TransformBroadcaster broadcaster(node);
+  tf2_ros::Buffer buffer(node->get_clock());
+  tf2_ros::TransformListener tf_listener(buffer);
 
   // declare parameters
   node->declare_parameter("mesh");
-  node->declare_parameter("world");
-  node->declare_parameter("camera");
-  node->declare_parameter("orbit_speed");
+  node->declare_parameter("base_frame");
+  node->declare_parameter("camera_frame");
   node->declare_parameter("framerate");
-  node->declare_parameter("radius");
   node->declare_parameter("focal_length");
-  node->declare_parameter("z");
   node->declare_parameter("width");
   node->declare_parameter("height");
 
@@ -65,17 +50,8 @@ int main(int argc, char** argv)
   std::string camera_frame;
   node->get_parameter_or<std::string>("camera_frame", camera_frame, "camera");
 
-  double orbit_speed;
-  node->get_parameter_or<double>("orbit_speed", orbit_speed, 1.0);
-
   double framerate;
   node->get_parameter_or<double>("framerate", framerate, 30.0);
-
-  double radius;
-  node->get_parameter_or<double>("radius", radius, 0.5);
-
-  double z;
-  node->get_parameter_or<double>("z", z, 0.5);
 
   double focal_length;
   node->get_parameter_or<double>("focal_length", focal_length, 550.0);
@@ -109,44 +85,32 @@ int main(int argc, char** argv)
   sim.add(*mesh_ptr, Eigen::Isometry3d::Identity());
 
   // In the main (rendering) thread, begin orbiting...
-  const auto start = std::chrono::steady_clock::now();
-
   rclcpp::Rate rate(framerate);
 
   while (rclcpp::ok())
   {
-    double dt = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
-
-    Eigen::Vector3d camera_pos(radius * cos(dt * orbit_speed), radius * sin(dt * orbit_speed), z);
-
-    Eigen::Vector3d look_at(0, 0, 0);
-
-    const auto pose = lookat(camera_pos, look_at, Eigen::Vector3d(0, 0, 1));
-
-    const auto depth_img = sim.render(pose);
-
-    cv::Mat cv_img;
-    gl_depth_sim::toCvImage16u(depth_img, cv_img);
-
-    cv_bridge::CvImage image;
-    image.header.stamp = node->now();
-    image.header.frame_id = camera_frame;
-    image.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
-    image.image = cv_img;
-    image_pub.publish(image.toImageMsg());
-
-    geometry_msgs::msg::TransformStamped transform_stamped;
-    transform_stamped.transform.translation.x = pose.translation().x();
-    transform_stamped.transform.translation.y = pose.translation().y();
-    transform_stamped.transform.translation.z = pose.translation().z();
-    transform_stamped.transform.rotation = tf2::toMsg(Eigen::Quaternion<double>(pose.linear()));
-
-    transform_stamped.header.stamp = image.header.stamp;
-    transform_stamped.header.frame_id = base_frame;
-    transform_stamped.child_frame_id = camera_frame;
-    broadcaster.sendTransform(transform_stamped);
-
     rate.sleep();
+    try
+    {
+      geometry_msgs::msg::TransformStamped tf_camera_st = buffer.lookupTransform(base_frame, camera_frame, tf2::TimePointZero);
+      const auto pose = tf2::transformToEigen(tf_camera_st);
+      const auto depth_img = sim.render(pose);
+
+      cv::Mat cv_img;
+      gl_depth_sim::toCvImage16u(depth_img, cv_img);
+
+      cv_bridge::CvImage image;
+      image.header.stamp = tf_camera_st.header.stamp;
+      image.header.frame_id = tf_camera_st.child_frame_id;
+      image.encoding = sensor_msgs::image_encodings::TYPE_16UC1;
+      image.image = cv_img;
+      image_pub.publish(image.toImageMsg());
+    }
+    catch (tf2::LookupException &e)
+    {
+      RCLCPP_ERROR_STREAM(node->get_logger(), e.what());
+    }
+
     rclcpp::spin_some(node);
   }
 

--- a/yak_ros2/src/demo/sim_tf_broadcaster.cpp
+++ b/yak_ros2/src/demo/sim_tf_broadcaster.cpp
@@ -1,0 +1,88 @@
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_eigen/tf2_eigen.h>
+
+#include <chrono>
+
+const static std::string DEFAULT_IMAGE_TOPIC = "image";
+
+static Eigen::Isometry3d lookat(const Eigen::Vector3d& origin, const Eigen::Vector3d& eye, const Eigen::Vector3d& up)
+{
+  Eigen::Vector3d z = (eye - origin).normalized();
+  Eigen::Vector3d x = z.cross(up).normalized();
+  Eigen::Vector3d y = z.cross(x).normalized();
+
+  auto p = Eigen::Isometry3d::Identity();
+  p.translation() = origin;
+  p.matrix().col(0).head<3>() = x;
+  p.matrix().col(1).head<3>() = y;
+  p.matrix().col(2).head<3>() = z;
+  return p;
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("sim_tf_broadcaster_node");
+
+  // Setup ROS interfaces
+  tf2_ros::TransformBroadcaster broadcaster(node);
+
+  // declare parameters
+  node->declare_parameter("base_frame");
+  node->declare_parameter("camera_frame");
+  node->declare_parameter("orbit_speed");
+  node->declare_parameter("hz");
+  node->declare_parameter("radius");
+  node->declare_parameter("z");
+
+  std::string base_frame;
+  node->get_parameter_or<std::string>("base_frame", base_frame, "world");
+
+  std::string camera_frame;
+  node->get_parameter_or<std::string>("camera_frame", camera_frame, "camera");
+
+  double orbit_speed;
+  node->get_parameter_or<double>("orbit_speed", orbit_speed, 1.0);
+
+  double hz;
+  node->get_parameter_or<double>("hz", hz, 30.0);
+
+  double radius;
+  node->get_parameter_or<double>("radius", radius, 0.5);
+
+  double z;
+  node->get_parameter_or<double>("z", z, 0.5);
+
+  const auto start = std::chrono::steady_clock::now();
+
+  rclcpp::Rate rate(hz);
+
+  while (rclcpp::ok())
+  {
+    double dt = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+
+    Eigen::Vector3d camera_pos(radius * cos(dt * orbit_speed), radius * sin(dt * orbit_speed), z);
+
+    Eigen::Vector3d look_at(0, 0, 0);
+
+    const auto pose = lookat(camera_pos, look_at, Eigen::Vector3d(0, 0, 1));
+
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    transform_stamped.transform.translation.x = pose.translation().x();
+    transform_stamped.transform.translation.y = pose.translation().y();
+    transform_stamped.transform.translation.z = pose.translation().z();
+    transform_stamped.transform.rotation = tf2::toMsg(Eigen::Quaternion<double>(pose.linear()));
+
+    transform_stamped.header.stamp = node->now();
+    transform_stamped.header.frame_id = base_frame;
+    transform_stamped.child_frame_id = camera_frame;
+    broadcaster.sendTransform(transform_stamped);
+
+    rate.sleep();
+    rclcpp::spin_some(node);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This splits the `yak_ros2_image_simulator` node into two functionally-separate nodes:

- `yak_ros2_image_simulator` now only performs a rate-based TF lookup of a frame and renders a simulated depth image at that frame's current pose looking towards a parameter-specified mesh. The TF frame must now be provided by an external broadcaster.

- `yak_ros2_tf_broadcaster` is a new node that broadcasts a TF frame orbiting a point at a given radius, height, and speed.

This makes it much easier to simulate scanning using a simulated industrial robot or other source of camera positional info, since you just need to substitute `yak_ros2_tf_broadcaster` for some other source for the camera TF frame such as a robot state publisher.

A few other changes added here as well:

- Switch to C++17 to address the [Eigen unaligned array assertion failure](https://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html).

- Fix handling of the `BUILD_DEMO` flag in `CMakeLists.txt` (setting `-DBUILD_DEMO=false` would still try to build the demo nodes).

